### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ implicit val dateTimeStringConverter = new StringConverter[DateTime] {
     }
 
     override def to(dateTime: DateTime): String = {
-      ISODateTimeFormat.dateTimeParser().print(dateTime)
+      ISODateTimeFormat.dateTime().print(dateTime)
     }
   }
 ```


### PR DESCRIPTION
A small correction in the 'Extending the library' paragraph. In the `dateTimeStringConverter` example, the function `to` has a mistake.
Current:

```
  override def to(dateTime: DateTime): String = {
        ISODateTimeFormat.dateTimeParser().print(dateTime)
      }
```

Trying to use it:

```
  import org.joda.time.DateTime
  import org.joda.time.format.ISODateTimeFormat
  import purecsv.safe.converter.StringConverter
  import purecsv.safe._
  import scala.util.Try

  implicit val dateTimeStringConverter = new StringConverter[DateTime] {
  override def tryFrom(str: String): Try[DateTime] = {
    Try(ISODateTimeFormat.dateTimeParser().parseDateTime(str))
  }

  override def to(dateTime: DateTime): String = {
    ISODateTimeFormat.dateTimeParser().print(dateTime)
  }
}

case class DateTimeSample(date: DateTime)

Seq(DateTimeSample(DateTime.now)).writeCSVToFileName("any")
```

throws `java.lang.UnsupportedOperationException: Printing not supported` in `joda-time`.

Should be:

```
    override def to(dateTime: DateTime): String = {
      ISODateTimeFormat.dateTime().print(dateTime)
    }
```
