### PR TITLE
make Converter/CSVReader Serializable for usage with Spark

### DIFF
--- a/shared/src/main/scala/purecsv/safe/package.scala
+++ b/shared/src/main/scala/purecsv/safe/package.scala
@@ -57,7 +57,7 @@ package object safe {
   implicit class CSVIterable[A](iter: Iterable[A])(implicit rfc: RawFieldsConverter[A])
     extends purecsv.csviterable.CSVIterable[A, RawFieldsConverter[A]](iter)(rfc)
 
-  trait CSVReader[A] {
+  trait CSVReader[A] extends Serializable {
 
     def rfc: RawFieldsConverter[A]
 

--- a/shared/src/main/scala/purecsv/unsafe/converter/Converter.scala
+++ b/shared/src/main/scala/purecsv/unsafe/converter/Converter.scala
@@ -15,7 +15,7 @@
 package purecsv.unsafe.converter
 
 /** Typeclass for Converters of A from/to B */
-trait Converter[A,B] {
+trait Converter[A,B] extends Serializable {
   /**
    * @param b The initial value
    * @return b converted to the type [[A]]

--- a/shared/src/main/scala/purecsv/unsafe/package.scala
+++ b/shared/src/main/scala/purecsv/unsafe/package.scala
@@ -54,7 +54,7 @@ package object unsafe {
   implicit class CSVIterable[A](iter: Iterable[A])(implicit rfc: RawFieldsConverter[A])
     extends purecsv.csviterable.CSVIterable[A, RawFieldsConverter[A]](iter)(rfc)
 
-  trait CSVReader[A] {
+  trait CSVReader[A] extends Serializable {
 
     def rfc: RawFieldsConverter[A]
 

--- a/shared/src/test/scala/purecsv/package.scala
+++ b/shared/src/test/scala/purecsv/package.scala
@@ -1,0 +1,21 @@
+package purecsv
+
+import java.io._
+
+package object util {
+  /**
+   * Utility function to serialize an object and immediately deserialize it back.
+   *
+   * @param obj an object of type T, should be Serializable
+   * @return the object of type T after being serialized and deserialized back
+   */
+  def serializeAndDeserialize[T](obj: T): T = {
+    val baos = new ByteArrayOutputStream()
+    val oos = new ObjectOutputStream(baos)
+    oos.writeObject(obj)
+
+    new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray))
+      .readObject()
+      .asInstanceOf[T]
+  }
+}

--- a/shared/src/test/scala/purecsv/unsafe/converter/ConverterSuite.scala
+++ b/shared/src/test/scala/purecsv/unsafe/converter/ConverterSuite.scala
@@ -16,9 +16,11 @@ package purecsv.unsafe.converter
 
 import purecsv.unsafe.converter.defaults.rawfields._
 import purecsv.unsafe.converter.defaults.string._
+import purecsv.util.serializeAndDeserialize
 import org.scalatest.{FunSuite, Matchers}
 import shapeless.{::, Generic, HNil}
 
+case class Event(ts: Long, msg: String)
 
 class ConverterSuite extends FunSuite with Matchers {
 
@@ -39,8 +41,6 @@ class ConverterSuite extends FunSuite with Matchers {
     conv.to("test" :: 1 :: HNil) should contain theSameElementsInOrderAs (Seq("\"test\"","1"))
     conv.from(Seq("foo","2")) should be ("foo" :: 2 :: HNil)
   }
-
-  case class Event(ts: Long, msg: String)
 
   test("conversion case class <-> String works") {
     val conv = RawFieldsConverter[Event]
@@ -74,5 +74,13 @@ class ConverterSuite extends FunSuite with Matchers {
     val event = new Event2(1,"foo")
     val expectedEvent = new Event2(1, "\"foo\"")
     conv.from(conv.to(event)) should be (expectedEvent)
+  }
+
+  test("serializing a RawFieldsConverter should work") {
+    val conv = RawFieldsConverter[Event]
+    val convDeserialized = serializeAndDeserialize(conv)
+
+    convDeserialized.to(Event(1,"foobar")) should contain theSameElementsInOrderAs(Seq("1","\"foobar\""))
+    convDeserialized.from(Seq("2","barfoo")) should be (Event(2,"barfoo"))
   }
 }

--- a/shared/src/test/scala/purecsv/unsafe/unsafeSuite.scala
+++ b/shared/src/test/scala/purecsv/unsafe/unsafeSuite.scala
@@ -18,13 +18,14 @@ import java.io.CharArrayReader
 import java.nio.file.Files
 
 import purecsv.unsafe._
+import purecsv.util.serializeAndDeserialize
 
 import org.scalatest.{FunSuite, Matchers}
 
+case class Event(ts: Long, msg: String, user: Option[Int])
 
 class unsafeSuite extends FunSuite with Matchers {
 
-  case class Event(ts: Long, msg: String, user: Option[Int])
   val events = Seq(Event(1,"foo",None),Event(2,"bar",Some(1)))
   val rawEvents = Seq("1,\"foo\",","2,\"bar\",1")
 
@@ -42,6 +43,18 @@ class unsafeSuite extends FunSuite with Matchers {
     file.deleteOnExit()
     events.writeCSVToFile(file)
     CSVReader[Event].readCSVFromFile(file) should contain theSameElementsInOrderAs(events)
+  }
+
+  test("serializing a CSVReader should work") {
+    val csvReader = CSVReader[Event]
+    val csvReaderDeserialized = serializeAndDeserialize(csvReader)
+
+    val result = csvReaderDeserialized.readCSVFromString("123|bar|\n456|foo|3", false, '|')
+
+    result.length should be (2)
+    result should be (List(
+      Event(123, "bar", None),
+      Event(456, "foo", Some(3))))
   }
 
 }


### PR DESCRIPTION
Hey there @melrief,

I am exploring using PureCSV with Spark, but unfortunately if I were to try to abstract over things or pull instantiations out of anonymous functions that get passed to Spark, I run into issues of serialization (a common problem in Sparkland).

Here's what I mean:

```scala
def loadCsv[T: Encoder: RawFieldsConverter](
  paths: String*
)(implicit spark: SparkSession): Dataset[T] = {
  import spark.implicits._

  val csvReader = CSVReader[T]

  spark.read
    .textFile(paths: _*)
    .flatMap { s =>
      val result = csvReader.readCSVFromString(
        s = s,
        delimiter = '|',
        skipHeader = false)

      result.collect { case Success(v) => v }
    }
}
```

The NotSerializable stack trace is left out for verbosity, but in this case both the `CSVReader` and the implicit `RawFieldsConverter[T]` generated by PureCSV + Shapeless aren't serializable.

If it's not too unreasonable of an ask, would it be ok to make these `Serializable`? As far as I know about precedence, cats went this route of making pretty much everything `Serializable` somewhere in the inheritance chain, e.g. https://github.com/typelevel/cats/blob/99b543b3a490e14ea219c8c57eb15ffa3d0c6340/kernel/src/main/scala/cats/kernel/Semigroup.scala#L9.

Are there any other base types in PureCSV that you would recommend making `Serializable` as well? My initial sense is that I've covered the major ones.

I would greatly appreciate a release if this is 👍 'd and merged!