### PR TITLE
Added in delimiter option to readCSVFromFileName

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,8 +63,9 @@ lazy val pureCSV = crossProject.crossType(CrossType.Full).in(new File(".")).
       "com.chuusai" %% "shapeless" % "2.3.2",
       compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
       "org.scalatest" %% "scalatest" % "3.0.1" % Test,
-      "com.github.marklister" %%% "product-collections" % "1.4.5"
-      ),
+      "com.github.marklister" %%% "product-collections" % "1.4.5",
+      "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.6"
+    ),
     resolvers ++= Seq(
       Resolver.sonatypeRepo("releases"),
       Resolver.sonatypeRepo("snapshots")

--- a/shared/src/main/scala/purecsv/unsafe/package.scala
+++ b/shared/src/main/scala/purecsv/unsafe/package.scala
@@ -92,7 +92,7 @@ package object unsafe {
     def readCSVFromFileName(fileName: String,
                             skipHeader: Boolean = false,
                             delimiter:Char = RecordSplitter.defaultFieldSeparator): List[A] = {
-      readCSVFromFile(new File(fileName), skipHeader)
+      readCSVFromFile(new File(fileName), skipHeader, delimiter)
     }
 
   }


### PR DESCRIPTION
Was using the readCSVFromFileName option and was trying to read in a tab delimited file, and realized that the delimiter option wasn't being set through the chain.

To get this to compile on my machine I had to add in  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.6" to the dependencies. 

Signed-off-by: Jacob Foard <jfoard@redventures.com>