### PR TITLE
release 1.3.11 for Java 11 users

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbt.Keys._
 lazy val buildSettings = Seq(
   organization := "io.kontainers",
   scalaVersion := "2.13.10",
-  crossScalaVersions := Seq("2.12.15", scalaVersion.value)
+  crossScalaVersions := Seq("2.12.17", scalaVersion.value)
 )
 
 lazy val publishSettings = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.8.3

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.3.11-SNAPSHOT"
+ThisBuild / version := "1.3.11"


### PR DESCRIPTION
make Java 11 version more easily available in certain environments by making 1.3.11-SNAPSHOT release 1.3.11
